### PR TITLE
chore(routing): support multi-env base paths (Vercel root, GoDaddy /s…

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,19 @@
     <link rel="preload" href="/fonts/montserrat-500.ttf" as="font" type="font/ttf" crossorigin>
     <link rel="stylesheet" href="/fonts/fonts.css">
     
-    <!-- Base href - set explicitly for both environments -->
+    <!-- Base href - set explicitly for multiple environments -->
     <script>
       // Detect environment and set appropriate base href
       const isVercel = window.location.hostname.includes('vercel.app');
-      const basePath = isVercel ? '/' : '/playground/';
+      const path = window.location.pathname || '/';
+      let basePath = '/';
+      if (isVercel) {
+        basePath = '/';
+      } else if (path.startsWith('/server/playground')) {
+        basePath = '/server/playground/';
+      } else {
+        basePath = '/playground/';
+      }
       
       // Always set base href explicitly
       const baseElement = document.createElement('base');
@@ -43,17 +51,17 @@
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
 
     <!-- PWA Meta Tags -->
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="manifest.json" />
     <meta name="theme-color" content="#D8AE48" />
     <meta name="background-color" content="#0a0a0a" />
     <meta name="display" content="standalone" />
     <meta name="orientation" content="portrait" />
     
     <!-- Apple Touch Icons -->
-    <link rel="apple-touch-icon" href="/icons/icon-192x192.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="/icons/icon-152x152.png" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-192x192.png" />
-    <link rel="apple-touch-icon" sizes="167x167" href="/icons/icon-192x192.png" />
+    <link rel="apple-touch-icon" href="icons/icon-192x192.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="icons/icon-152x152.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="icons/icon-192x192.png" />
+    <link rel="apple-touch-icon" sizes="167x167" href="icons/icon-192x192.png" />
     
     <!-- Apple PWA Meta Tags -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -62,17 +70,17 @@
     
     <!-- Microsoft Tiles -->
     <meta name="msapplication-TileColor" content="#D8AE48" />
-    <meta name="msapplication-TileImage" content="/icons/icon-144x144.png" />
-    <meta name="msapplication-config" content="/browserconfig.xml" />
+    <meta name="msapplication-TileImage" content="icons/icon-144x144.png" />
+    <meta name="msapplication-config" content="browserconfig.xml" />
     
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/icons/icon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/icons/icon-16x16.png" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="icon" type="image/png" sizes="32x32" href="icons/icon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="icons/icon-16x16.png" />
   </head>
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,9 +23,20 @@ import ProtectedRoute from "./admin/components/ProtectedRoute";
 const queryClient = new QueryClient();
 
 const App = () => {
-  // Detect environment for dynamic basename
+  // Detect environment and set dynamic basename
   const isVercel = window.location.hostname.includes('vercel.app');
-  const basename = isVercel ? '' : '/playground';
+  const path = window.location.pathname || '/';
+  let basename = '';
+  if (isVercel) {
+    // Vercel deploy at root
+    basename = '';
+  } else if (path.startsWith('/server/playground')) {
+    // GoDaddy deploy under /server/playground
+    basename = '/server/playground';
+  } else {
+    // Local/self-hosted default under /playground
+    basename = '/playground';
+  }
   
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
…erver/playground)

- App.tsx: dynamic BrowserRouter basename for vercel root, /server/playground, and local /playground
- index.html: dynamic <base> computation; make manifest/icons/favicon/module script relative to base
- Fixes manifest 401 in protected previews by avoiding absolute path when base is prefixed

Docs: no behavior change for Vercel root; GoDaddy mounting under /server/playground now works without code changes.